### PR TITLE
A fix for GlassFish issue 24101

### DIFF
--- a/concurrent-connector/pom.xml
+++ b/concurrent-connector/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.omnifaces</groupId>
         <artifactId>omniconcurrent-parent</artifactId>
-        <version>3.0.0-RC5</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>concurrent-connector</artifactId>

--- a/concurrent-extras/pom.xml
+++ b/concurrent-extras/pom.xml
@@ -47,7 +47,7 @@
     <parent>
         <groupId>org.omnifaces</groupId>
         <artifactId>omniconcurrent-parent</artifactId>
-        <version>3.0.0-RC5</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>concurrent-extras</artifactId>

--- a/concurrent-impl/pom.xml
+++ b/concurrent-impl/pom.xml
@@ -49,7 +49,7 @@
    <parent>
         <groupId>org.omnifaces</groupId>
         <artifactId>omniconcurrent-parent</artifactId>
-        <version>3.0.0-RC5</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>  
     <artifactId>concurrent-impl</artifactId>
     <packaging>glassfish-jar</packaging>

--- a/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
+++ b/concurrent-impl/src/main/java/org/glassfish/concurrent/runtime/ContextSetupProviderImpl.java
@@ -156,7 +156,7 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
 
         initialiseServices();
 
-        for (String contextType : propagated) {
+        for (String contextType : contextPropagate) {
             switch (contextType) {
                 case CONTEXT_TYPE_CLASSLOADING:
                     classloading = true;
@@ -206,31 +206,31 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
             }
         }
         // check, if there is no unexpected provider name
-        verifyProviders(contextPropagate);
-        verifyProviders(contextClear);
-        verifyProviders(contextUnchanged);
+        Set<String> verifiedContextPropagate = filterVerifiedProviders(contextPropagate);
+        Set<String> verifiedContextClear = filterVerifiedProviders(contextClear);
+        Set<String> verifiedContextUnchanged = filterVerifiedProviders(contextUnchanged);
 
         ComponentInvocation currentInvocation = invocationManager.getCurrentInvocation();
         if (currentInvocation != null) {
-            if (contextPropagate.contains(CONTEXT_TYPE_NAMING)) {
+            if (verifiedContextPropagate.contains(CONTEXT_TYPE_NAMING)) {
                 savedInvocation = createComponentInvocation(currentInvocation);
             }
-            if (contextClear.contains(CONTEXT_TYPE_NAMING)) {
+            if (verifiedContextClear.contains(CONTEXT_TYPE_NAMING)) {
                 savedInvocation = new ComponentInvocation();
             }
         }
         boolean useTransactionOfExecutionThread = (transactionManager == null && useTransactionOfExecutionThread(contextObjectProperties))
-                || contextUnchanged.contains(CONTEXT_TYPE_WORKAREA);
+                || verifiedContextUnchanged.contains(CONTEXT_TYPE_WORKAREA);
 
         // store the snapshots of the current state
         List<ThreadContextSnapshot> threadContextSnapshots = new ArrayList<>();
         // remember values from propagate and clear lists
-        contextPropagate.stream()
+        verifiedContextPropagate.stream()
                 .map((provider) -> allThreadContextProviders.get(provider))
                 .filter(snapshot -> snapshot != null) // ignore standard providers like CONTEXT_TYPE_CLASSLOADING
                 .map(snapshot -> snapshot.currentContext(contextObjectProperties))
                 .forEach(snapshot -> threadContextSnapshots.add(snapshot));
-        contextClear.stream()
+        verifiedContextClear.stream()
                 .map((provider) -> allThreadContextProviders.get(provider))
                 .filter(snapshot -> snapshot != null)
                 .map(snapshot -> snapshot.clearedContext(contextObjectProperties))
@@ -452,7 +452,8 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
         return ManagedTask.SUSPEND;
     }
 
-    private void verifyProviders(Set<String> providers) {
+    private Set<String> filterVerifiedProviders(Set<String> providers) {
+        HashSet<String> filtered = new HashSet<>();
         Iterator<String> providerIter = providers.iterator();
         while (providerIter.hasNext()) {
             String provider = providerIter.next();
@@ -462,16 +463,18 @@ public class ContextSetupProviderImpl implements ContextSetupProvider {
                 case CONTEXT_TYPE_NAMING:
                 case CONTEXT_TYPE_WORKAREA:
                 case ContextServiceDefinition.ALL_REMAINING:
-                    // OK, they are known
+                    filtered.add(provider);
                     break;
                 default:
-                    if (!allThreadContextProviders.containsKey(provider)) {
+                    if (allThreadContextProviders.containsKey(provider)) {
+                        filtered.add(provider);
+                    } else {
                         logger.severe("Thread context provider '" + provider + "' is not registered in WEB-APP/services/jakarta.enterprise.concurrent.spi.ThreadContextProvider and will be ignored!");
-                        providerIter.remove();
                     }
                     break;
             }
         }
+        return filtered;
     }
 
     private void addToRemainingIfNotPresent(String contextType) {

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
 	<groupId>org.omnifaces</groupId>
 	<artifactId>omniconcurrent-parent</artifactId>
-	<version>3.0.0-RC5</version>
+	<version>3.0.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>OmniConcurrent Parent</name>


### PR DESCRIPTION
A fix for https://github.com/eclipse-ee4j/glassfish/issues/24101

Unverified contexts are not removed globally so the global configuration isn't changed. This is the main fix.

Config is initialized also from remaining contexts. This doesn't fix the reported issue but it fixes another issue I realize during debugging. This fix allows propagating the classloader (application context) if it's not mentioned anywhere. Without that, the class loader isn't propagated by default or when REMAINING is propagated, unless APPLICATION is explicitly set to propagate.

A test to reproduce the issue is in this draft PR for GlassFish: https://github.com/eclipse-ee4j/glassfish/pull/24102
